### PR TITLE
Added feature toggles on extension popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ We welcome contributions!
 ## 📄 License
 
 Distributed under the MIT License. See `LICENSE` for details.
+
+## 🔧 Feature Toggles
+
+You can enable/disable individual features from the extension popup. These settings are saved to Chrome's local storage and persist across browser restarts.
+
+Toggles available:
+- Problem Assistant: Sidebar on problem pages with bookmark, notes and optional stopwatch.
+- Stopwatch: Show/hide the stopwatch row inside Problem Assistant.
+- Advanced Filtering: Replace the default tag filter on the Problemset page with an advanced filter panel.
+- Enhanced Data Table: Replace the Problemset table with a richer data table.
+- Chat Panel (experimental): Mount a chat panel overlay.
+
+Changes take effect immediately on open tabs; the extension listens for updates and mounts/unmounts features live.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,7 +1524,6 @@
 			"integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
 				"@octokit/graphql": "^9.0.2",
@@ -2298,7 +2297,6 @@
 			"integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.14.0"
 			}
@@ -2335,7 +2333,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
 			"integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.0.2"
 			}
@@ -2412,7 +2409,6 @@
 			"integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.35.1",
 				"@typescript-eslint/types": "8.35.1",
@@ -2651,7 +2647,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4338,7 +4333,6 @@
 			"integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7317,7 +7311,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
 			"integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7327,7 +7320,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
 			"integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.26.0"
 			},
@@ -7533,7 +7525,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@nodeutils/defaults-deep": "1.1.0",
 				"@octokit/rest": "22.0.0",
@@ -8393,7 +8384,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8572,7 +8562,6 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -8755,7 +8744,6 @@
 			"integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.6",
@@ -8866,7 +8854,6 @@
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},

--- a/src/content/components/ProblemAssistantPanel.tsx
+++ b/src/content/components/ProblemAssistantPanel.tsx
@@ -240,16 +240,20 @@ const ProblemAssistantPanel: React.FC = () => {
               </tr>
             </>
           )}
-          <tr>
-            <td className="left" style={{ padding: "0em 1em" }}>
-              <Stopwatch problemKey={PROBLEM_KEY} />
-            </td>
-          </tr>
-          <tr>
-            <td className="left dark" style={{ padding: "0.5em 1em" }}>
-              <span className="contest-state-regular">Time is running..! </span>
-            </td>
-          </tr>
+          {document.documentElement.getAttribute("data-cf-mentor-hide-stopwatch") !== "true" && (
+            <>
+              <tr>
+                <td className="left" style={{ padding: "0em 1em" }}>
+                  <Stopwatch problemKey={PROBLEM_KEY} />
+                </td>
+              </tr>
+              <tr>
+                <td className="left dark" style={{ padding: "0.5em 1em" }}>
+                  <span className="contest-state-regular">Time is running..! </span>
+                </td>
+              </tr>
+            </>
+          )}
         </tbody>
       </table>
     </div>

--- a/src/popup/PopupApp.css
+++ b/src/popup/PopupApp.css
@@ -1,20 +1,86 @@
+/* Container */
 .popup-container {
-  padding: 1rem;
-  text-align: center;
+  padding: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.popup-container h1 {
-  font-size: 1.2rem;
-  margin-bottom: 0.5rem;
+
+/* Top header band */
+.popup-header {
+  background: #d1ddf8; /* blue background like screenshot 2 */
+  padding: 12px 16px;
+  border-radius: 6px;
 }
 
-.popup-container p {
-  font-size: 0.9rem;
-  margin-bottom: 1rem;
+.popup-title-text {
+  color: #1e3a8a; /* darker blue for text */
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.1;
+  margin: 0;
 }
 
-.popup-container button {
-  padding: 8px 16px;
+.popup-title {
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+
+.popup-title a { color: #000; text-decoration: underline; }
+
+.popup-subtitle {
+  color: #333;
+  background: #f5f5f5;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  padding: 8px;
+  margin-bottom: 10px;
+}
+
+.popup-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+}
+
+/* Toggle row */
+.cf-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 0;
+}
+
+.cf-toggle.disabled {
+  opacity: 0.6;
+}
+
+.cf-checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: #3B5998;
+  margin-top: 2px;
+}
+
+.cf-toggle-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.cf-toggle-title {
+  font-weight: bold;
+}
+
+.cf-toggle-desc {
+  color: #666;
+  font-size: 12px;
+}
+
+/* Button */
+.cf-button {
+  width: 100%;
+  padding: 10px 12px;
   background-color: #3B5998;
   color: white;
   border: none;
@@ -22,4 +88,10 @@
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
+  margin-top: 4px;
+}
+
+.cf-button:disabled {
+  opacity: 0.7;
+  cursor: default;
 }

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -3,6 +3,7 @@ export const EXTENSION_CONFIG = {
 		CHAT_HISTORY: "chatHistory",
 		USER_PREFERENCES: "userPreferences",
 		PAGE_CONTEXT: "pageContext",
+		FEATURE_FLAGS: "featureFlags",
 	},
 	API: {
 		BASE_URL: "https://api.openai.com/v1",

--- a/src/shared/stores/featureFlags.ts
+++ b/src/shared/stores/featureFlags.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import { EXTENSION_CONFIG } from "../constants/config";
+
+export type FeatureKey =
+  | "problemAssistant" // bookmark + notes + stopwatch panel
+  | "stopwatch"
+  | "advancedFiltering"
+  | "dataTable";
+
+export type FeatureFlags = Record<FeatureKey, boolean>;
+
+const DEFAULT_FLAGS: FeatureFlags = {
+  problemAssistant: true,
+  stopwatch: true,
+  advancedFiltering: true,
+  dataTable: true,
+};
+
+interface FeatureFlagsState {
+  flags: FeatureFlags;
+  initialized: boolean;
+  setFlag: (key: FeatureKey, value: boolean) => void;
+  load: () => Promise<void>;
+}
+
+function loadFlagsFromStorage(): Promise<FeatureFlags> {
+  return new Promise((resolve) => {
+    chrome.storage.local.get([EXTENSION_CONFIG.STORAGE_KEYS.FEATURE_FLAGS], (res) => {
+      const stored = res[EXTENSION_CONFIG.STORAGE_KEYS.FEATURE_FLAGS] as FeatureFlags | undefined;
+      resolve({ ...DEFAULT_FLAGS, ...(stored ?? {}) });
+    });
+  });
+}
+
+function saveFlagsToStorage(flags: FeatureFlags): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ [EXTENSION_CONFIG.STORAGE_KEYS.FEATURE_FLAGS]: flags }, () => resolve());
+  });
+}
+
+export const useFeatureFlags = create<FeatureFlagsState>((set, get) => ({
+  flags: DEFAULT_FLAGS,
+  initialized: false,
+  setFlag: (key, value) => {
+    const next = { ...get().flags, [key]: value };
+    set({ flags: next });
+    saveFlagsToStorage(next);
+
+    // Inform all contexts to update feature mounts in-place
+    chrome.runtime?.sendMessage?.({ type: "cf-mentor:feature-flags-updated", payload: next });
+  },
+  load: async () => {
+    const flags = await loadFlagsFromStorage();
+    set({ flags, initialized: true });
+  },
+}));
+
+// Utility for non-React contexts
+export async function getFeatureFlags(): Promise<FeatureFlags> {
+  return loadFlagsFromStorage();
+}


### PR DESCRIPTION
## Summary
Added feature toggle UI in extension popup with persistent state management.

Fixes: #8 

## Changes
- added toggle checkboxes for stopwatch, problem assistant, advanced filtering and enhanced data table in popup UI
- toggles maintain persistence even after browser restart

## How to test
- open extension popup
- toggle each feature checkbox (Stopwatch, Advanced Filtering, etc.)
- close and reopen popup to verify toggles persist. also try with browser restart

## Notes
- Attaching an image of the popup ui below
<img width="474" height="462" alt="image" src="https://github.com/user-attachments/assets/13ac2592-be3b-48e4-8e36-0ff36519351f" />